### PR TITLE
GAIN-12: Refactor legacy validation to use new funcs()

### DIFF
--- a/gallant_input/ais/payload.py
+++ b/gallant_input/ais/payload.py
@@ -17,7 +17,7 @@ Example Usage:
 # Local Imports
 from gallant_input.ais.constants import AIS_PAYLOAD_MAX_SLOTS, AIS_PAYLOAD_SLOT_LEN
 from gallant_input.ais.payload_info import AISPayloadInfo
-from gallant_input.validation import validate_binary_bytes, validate_type
+from gallant_input.validation import validate_bool, validate_binary_bytes
 
 
 class AISPayload:
@@ -59,7 +59,7 @@ class AISPayload:
             ValueError: Invalid value.
         """
         # INPUT VALIDATION
-        validate_type(force, 'force', bool)
+        validate_bool(force, 'force')
 
         # VALIDATION
         if self._validated is False or force is True:

--- a/gallant_input/converters.py
+++ b/gallant_input/converters.py
@@ -3,7 +3,7 @@
 # Standard Imports
 # Third Party Imports
 # Local Imports
-from gallant_input.validation import validate_bytes, validate_type
+from gallant_input.validation import validate_bytes, validate_int
 
 
 def convert_bin_bytes_to_int(binary: bytes) -> int:
@@ -69,8 +69,8 @@ def convert_int_to_bin_bytes(number: int, min_width: int = 8) -> bytes:
         TypeError: Invalid data type.
         ValueError: Invalid value (e.g., min_width may not be negative).
     """
-    validate_type(var=number, var_name='number', var_type=int)
-    validate_type(var=min_width, var_name='min_width', var_type=int)
+    validate_int(number, 'number')
+    validate_int(min_width, 'min_width')
     if min_width < 0:
         raise ValueError(f'Invalid value for "min_width": {min_width}')
     return format(number, f'0{str(min_width)}b').encode('ascii')

--- a/gallant_input/data_analysis.py
+++ b/gallant_input/data_analysis.py
@@ -6,8 +6,8 @@ from math import floor
 from typing import List
 # Third Party Imports
 # Local Imports
-from gallant_input.validation import (validate_bytes_or_str, validate_list, validate_pos_int,
-                                      validate_type)
+from gallant_input.validation import (validate_bool, validate_bytes_or_str, validate_list,
+                                      validate_pos_int)
 
 
 def compare_streams(stream1: bytes | str, stream2: bytes | str, show_index: bool = True) -> int:
@@ -41,7 +41,7 @@ def compare_streams(stream1: bytes | str, stream2: bytes | str, show_index: bool
     if not isinstance(stream1, type(stream2)):
         raise TypeError(f'The type of stream1 "{type(stream1)}" must be the same '
                         f'as stream2 "{type(stream2)}"')
-    validate_type(show_index, 'show_index', bool)
+    validate_bool(show_index, 'show_index')
 
     # PREPARE
     # Properly format the missing character
@@ -185,7 +185,7 @@ def find_dense_repeats(haystack: bytes | str,
     # haystack
     # Handled by find_common_repeats()
     # reverse
-    validate_type(reverse, 'reverse', bool)
+    validate_bool(reverse, 'reverse')
 
     # FIND THEM
     repeats = _find_dense_repeats(haystack)

--- a/gallant_input/filters.py
+++ b/gallant_input/filters.py
@@ -9,9 +9,9 @@ import numpy
 # Local Imports
 from gallant_input.constants import FIRWIN_HPF, FIRWIN_LPF
 from gallant_input.convolvemode import ConvolveMode
-from gallant_input.validation import (validate_arraylike, validate_float, validate_ndarray,
-                                      validate_pos_float, validate_pos_int, validate_string,
-                                      validate_type)
+from gallant_input.validation import (validate_arraylike, validate_bool, validate_float,
+                                      validate_ndarray, validate_pos_float, validate_pos_int,
+                                      validate_string, validate_type)
 
 # I didn't do it this time.  It was firwin()!
 # pylint: disable=too-many-arguments, too-many-positional-arguments
@@ -254,7 +254,7 @@ def _validate_cutoff(cutoff: float | ArrayLike, cutoff_name: str, ratio: bool) -
     cutoff_limit = 0.99999999999999994  # The arbitrary upper end limit for a cutoff ratio
 
     # INPUT VALIDATION
-    validate_type(var=ratio, var_name='ratio', var_type=bool)
+    validate_bool(ratio, 'ratio')
     _validate_cutoff_type(cutoff, cutoff_name)
     validate_pos_float(cutoff, cutoff_name)  # Cutoff must be positive, regardless
     if ratio:

--- a/gallant_input/rds/block.py
+++ b/gallant_input/rds/block.py
@@ -8,7 +8,7 @@ from gallant_input.rds.block_id import BlockID
 from gallant_input.rds.constants import (RDS_BLOCK_LEN, RDS_BLOCK_DATA_LEN, RDS_BLOCK_CWORD_LEN,
                                          RDS_CRC_POLY)
 from gallant_input.rds.exceptions import RDSBlockIDMismatch, RDSIntegrityFailure
-from gallant_input.validation import validate_binary_bytes, validate_type
+from gallant_input.validation import validate_bool, validate_binary_bytes, validate_type
 
 
 class RDSBlock:
@@ -80,7 +80,7 @@ class RDSBlock:
         crc = None  # Calculated CRC as an integer
 
         # VALIDATION
-        validate_type(force, 'force', bool)
+        validate_bool(force, 'force')
         self._validate_internals(force=force)
 
         # PREPARE
@@ -235,7 +235,7 @@ class RDSBlock:
         """
         if self._validated is False or force is True:
             # self._validated
-            validate_type(var=self._validated, var_name='_validated attribute', var_type=bool)
+            validate_bool(self._validated, '_validated attribute')
             # self._rds_block
             self._validate_rds_block()
             # self._rds_block_id

--- a/gallant_input/rds/block.py
+++ b/gallant_input/rds/block.py
@@ -8,7 +8,8 @@ from gallant_input.rds.block_id import BlockID
 from gallant_input.rds.constants import (RDS_BLOCK_LEN, RDS_BLOCK_DATA_LEN, RDS_BLOCK_CWORD_LEN,
                                          RDS_CRC_POLY)
 from gallant_input.rds.exceptions import RDSBlockIDMismatch, RDSIntegrityFailure
-from gallant_input.validation import validate_bool, validate_binary_bytes, validate_type
+from gallant_input.validation import (validate_bool, validate_binary_bytes, validate_int,
+                                      validate_type)
 
 
 class RDSBlock:
@@ -143,7 +144,7 @@ class RDSBlock:
         cwrd_int = convert_bin_bytes_to_int(self._rds_block_cwrd)  # Checkword as an int
 
         # INPUT VALIDATION
-        validate_type(crc, 'crc', int)
+        validate_int(crc, 'crc')
         validate_type(block_id, 'block_id', BlockID)
 
         # VALIDATE IT

--- a/gallant_input/rds/collection.py
+++ b/gallant_input/rds/collection.py
@@ -8,7 +8,7 @@ from gallant_input.converters import convert_bin_bytes_to_hex_str
 from gallant_input.rds.exceptions import RDSIntegrityFailure, RDSPICodeMismatch
 from gallant_input.rds.group import RDSGroup
 from gallant_input.rds.picode import RDSPICode
-from gallant_input.validation import validate_type
+from gallant_input.validation import validate_bool, validate_type
 
 
 class RDSCollection:
@@ -89,7 +89,7 @@ class RDSCollection:
             TypeError: Invalid data type.
             ValueError: Invalid value.
         """
-        validate_type(force, 'force', bool)
+        validate_bool(force, 'force')
         self._validate_internals(force=force)
 
     # CLASS HELPER METHODS
@@ -165,7 +165,7 @@ class RDSCollection:
         """Validate the private attributes once."""
         if self._validated is False or force is True:
             # self._validated
-            validate_type(var=self._validated, var_name='_validated attribute', var_type=bool)
+            validate_bool(self._validated, '_validated attribute')
             # self._picode_dict
             validate_type(var=self._picode_dict, var_name='internal dictionary', var_type=dict)
             for pi_code, rds_pi_code_obj in self._picode_dict.items():

--- a/gallant_input/rds/group.py
+++ b/gallant_input/rds/group.py
@@ -11,7 +11,7 @@ from gallant_input.rds.exceptions import (RDSBlockIDMismatch, RDSIntegrityFailur
                                           RDSMsgGroupTypeMissing)
 from gallant_input.rds.mgt.rds_msg_group_type00 import RDSMsgGroupType00
 from gallant_input.rds.mgt.rds_msg_group_type02 import RDSMsgGroupType02
-from gallant_input.validation import validate_bytes, validate_type
+from gallant_input.validation import validate_bool, validate_bytes
 
 
 # pylint: disable=too-many-instance-attributes
@@ -136,7 +136,7 @@ class RDSGroup:
             TypeError: Invalid data type.
             ValueError: Invalid value.
         """
-        validate_type(force, 'force', bool)
+        validate_bool(force, 'force')
         if self._verified is False or force is True:
             # VALIDATION
             self._validate_internals()
@@ -197,9 +197,9 @@ class RDSGroup:
         """Validate the private attributes once."""
         if self._validated is False:
             # self._validated
-            validate_type(var=self._validated, var_name='_validated attribute', var_type=bool)
+            validate_bool(self._validated, '_validated attribute')
             # self._murica
-            validate_type(var=self._murica, var_name='assume_na', var_type=bool)
+            validate_bool(self._murica, 'assume_na')
             # self._rds_group
             self._validate_rds_group()
             self._validated = True

--- a/gallant_input/rds/mgt/rds_msg_group_type.py
+++ b/gallant_input/rds/mgt/rds_msg_group_type.py
@@ -40,7 +40,7 @@ class RDSMsgGroupType(ABC):
         # Functionality is defined in the sub-class when this method is overridden
         # Start with this code block...
         # if self._validated is not True:
-        #     validate_type(self._validated, 'internal attribute _validated', bool)  # Validate attr
+        #     validate_bool(self._validated, 'internal attribute _validated')  # Validate attr
         #     validate_binary_bytes(self.msg_ver, 'msg_ver', 1)  # Validate attr
         #     self._validated = True  # Done
 

--- a/gallant_input/rds/mgt/rds_msg_group_type00.py
+++ b/gallant_input/rds/mgt/rds_msg_group_type00.py
@@ -8,7 +8,7 @@ from gallant_input.converters import convert_bin_bytes_to_int
 from gallant_input.rds.constants import RDS_BLOCK_DATA_LEN
 from gallant_input.rds.exceptions import RDSFeatureUnavailable
 from gallant_input.rds.mgt.rds_msg_group_type import RDSMsgGroupType
-from gallant_input.validation import validate_binary_bytes, validate_type
+from gallant_input.validation import validate_binary_bytes, validate_bool
 
 
 # pylint: disable=duplicate-code
@@ -45,7 +45,7 @@ class RDSMsgGroupType00(RDSMsgGroupType):
     def validate_content(self) -> None:
         """Validate the contents of the dataclass: type, content, length, format."""
         if self._validated is not True:
-            validate_type(self._validated, 'internal attribute _validated', bool)
+            validate_bool(self._validated, 'internal attribute _validated')
             validate_binary_bytes(self.msg_ver, 'msg_ver', 1)
             validate_binary_bytes(self.di, 'di', 1)
             validate_binary_bytes(self.char_seg, 'char_seg', 2)

--- a/gallant_input/rds/mgt/rds_msg_group_type02.py
+++ b/gallant_input/rds/mgt/rds_msg_group_type02.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from gallant_input.converters import convert_bin_bytes_to_int
 from gallant_input.rds.constants import RDS_BLOCK_DATA_LEN
 from gallant_input.rds.mgt.rds_msg_group_type import RDSMsgGroupType
-from gallant_input.validation import validate_binary_bytes, validate_type
+from gallant_input.validation import validate_binary_bytes, validate_bool
 
 
 # pylint: disable=duplicate-code
@@ -41,7 +41,7 @@ class RDSMsgGroupType02(RDSMsgGroupType):
     def validate_content(self) -> None:
         """Validate the contents of the dataclass: type, content, length, format."""
         if self._validated is not True:
-            validate_type(self._validated, 'internal attribute _validated', bool)
+            validate_bool(self._validated, 'internal attribute _validated')
             validate_binary_bytes(self.msg_ver, 'msg_ver', 1)
             validate_binary_bytes(self.char_seg, 'char_seg', 4)
             validate_binary_bytes(self.block3_data, 'block3_data', 16)

--- a/gallant_input/rds/picode.py
+++ b/gallant_input/rds/picode.py
@@ -8,8 +8,8 @@ from gallant_input.rds.constants import RDS_BLOCK_DATA_LEN
 from gallant_input.rds.exceptions import (RDSIntegrityFailure, RDSMsgGroupTypeMissing,
                                           RDSPICodeMismatch)
 from gallant_input.rds.group import RDSGroup
-from gallant_input.validation import (validate_binary_bytes, validate_list, validate_string,
-                                      validate_type)
+from gallant_input.validation import (validate_binary_bytes, validate_bool, validate_list,
+                                      validate_string, validate_type)
 
 
 class RDSPICode:
@@ -99,7 +99,7 @@ class RDSPICode:
 
         # VALIDATION
         self.verify_pi_code_integrity()
-        validate_type(sanitize, 'sanitize', bool)
+        validate_bool(sanitize, 'sanitize')
 
         # GET IT
         # Form the list of RDSMsgGroupType02()s
@@ -181,7 +181,7 @@ class RDSPICode:
             TypeError: Invalid data type.
             ValueError: Invalid value.
         """
-        validate_type(force, 'force', bool)
+        validate_bool(force, 'force')
         self._validate_internals(force=force)
 
     # CLASS HELPER METHODS
@@ -255,7 +255,7 @@ class RDSPICode:
         """Validate the private attributes once."""
         if self._validated is False or force is True:
             # self._validated
-            validate_type(var=self._validated, var_name='_validated attribute', var_type=bool)
+            validate_bool(self._validated, '_validated attribute')
             # self._pi_code
             validate_binary_bytes(validate_this=self._pi_code, param_name='pi_code',
                                   exact_len=RDS_BLOCK_DATA_LEN)

--- a/gallant_input/rds/picode.py
+++ b/gallant_input/rds/picode.py
@@ -8,8 +8,8 @@ from gallant_input.rds.constants import RDS_BLOCK_DATA_LEN
 from gallant_input.rds.exceptions import (RDSIntegrityFailure, RDSMsgGroupTypeMissing,
                                           RDSPICodeMismatch)
 from gallant_input.rds.group import RDSGroup
-from gallant_input.validation import (validate_binary_bytes, validate_bool, validate_list,
-                                      validate_string, validate_type)
+from gallant_input.validation import (validate_binary_bytes, validate_bool, validate_int,
+                                      validate_list, validate_string, validate_type)
 
 
 class RDSPICode:
@@ -290,7 +290,7 @@ def _combine_offset_dict(offset_dict: dict, num_keys: int, missing: str = '?') -
     validate_string(missing, 'missing', can_be_empty=True)
     validate_type(offset_dict, 'offset_dict', dict)
     for key, val in offset_dict.items():
-        validate_type(key, 'offset_dict key', int)
+        validate_int(key, 'offset_dict key')
         validate_string(val, 'offset_dict value', can_be_empty=False)
         if width is None:
             width = len(val)
@@ -373,6 +373,6 @@ def _pad_chunk(prev_offset: int | None, curr_offset: int, chunk: str, missing: s
 
 def _validate_not_negative_int(var: int, var_name: str) -> None:
     """Validate an integer as not negative (>= 0)."""
-    validate_type(var, var_name, int)
+    validate_int(var, var_name)
     if var < 0:
         raise ValueError(f'The "{var_name}" argument may not be negative: {var}')

--- a/gallant_input/sigmfmetaparser.py
+++ b/gallant_input/sigmfmetaparser.py
@@ -12,7 +12,7 @@ import sigmf
 # Local Imports
 from gallant_input.logger import Logger
 from gallant_input.sigmfdtypeinfo import SigMFDTypeInfo
-from gallant_input.validation import validate_path, validate_string, validate_type
+from gallant_input.validation import validate_int, validate_path, validate_string
 
 
 class SigMFMetaParser:
@@ -351,7 +351,7 @@ class SigMFMetaParser:
         # obj_name && key
         self._validate_obj_name_key_pair(obj_name=obj_name, key=key)
         # index
-        validate_type(var=index, var_name='index', var_type=int)
+        validate_int(index, 'index')
         if index < 0:
             raise TypeError(f'The "index" value is invalid: {index}')
 

--- a/gallant_input/validation.py
+++ b/gallant_input/validation.py
@@ -117,7 +117,7 @@ def validate_bytes(validate_this: bytes, param_name: str, exact_len: int = None)
     validate_string(validate_this=param_name, param_name='param_name', can_be_empty=False)
     # exact_len
     if exact_len is not None:
-        validate_type(exact_len, 'exact_len', int)
+        validate_int(exact_len, 'exact_len')
         if exact_len > -1:
             validate_len = True
     # validate_this
@@ -181,7 +181,7 @@ def validate_float(validate_this: float, param_name: str) -> None:
     validate_type(validate_this, param_name, float)
 
 
-def validate_int(validate_this: Path, param_name: str) -> None:
+def validate_int(validate_this: int, param_name: str) -> None:
     """Validate validate_this as an int object.
 
     Args:

--- a/gallant_input/validation.py
+++ b/gallant_input/validation.py
@@ -5,11 +5,11 @@ validated.
 
     Typical usage example:
 
-    from gallant_input.validation import validate_list, validate_string, validate_type
+    from gallant_input.validation import validate_bool, validate_list, validate_string
 
+    validate_bool(self._as_root, 'as_root')
     validate_list(self._options, 'options', can_be_empty=True)
     validate_string(self._makefile_rule, 'makefile_rule')
-    validate_type(self._as_root, 'as_root', bool)
 """
 # Standard Imports
 from pathlib import Path
@@ -300,7 +300,7 @@ def validate_path(validate_this: Path, param_name: str, must_exist: bool = True)
     """
     # INPUT VALIDATION
     validate_string(param_name, 'param_name', can_be_empty=True)
-    validate_type(must_exist, 'must_exist', bool)
+    validate_bool(must_exist, 'must_exist')
     validate_type(validate_this, param_name, Path)
     if must_exist and not validate_this.exists():
         raise FileNotFoundError(f'Unable to locate "{param_name}" path: '


### PR DESCRIPTION
Refactored some old `validate_type()` calls to utilize newly added `validation` module functions:

- `validate_int()`
- `validate_bool()`

#15 (`GAIN-10`) was chosen as the upstream branch to avoid merge conflicts (even though `GAIN-10` is likely 100% ready to go).